### PR TITLE
Add a `glob_read` method for reading multiple configs at once

### DIFF
--- a/flight_config.gemspec
+++ b/flight_config.gemspec
@@ -59,6 +59,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'tty-config'
 
   spec.add_development_dependency "bundler", "~> 1.16"
+  spec.add_runtime_dependency     'fakefs'
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency 'pry-byebug'

--- a/lib/flight_config.rb
+++ b/lib/flight_config.rb
@@ -28,6 +28,7 @@
 
 require "flight_config/version"
 require 'flight_config/deleter'
+require 'flight_config/globber'
 require 'flight_config/log'
 require 'flight_config/reader'
 require 'flight_config/updater'

--- a/lib/flight_config/globber.rb
+++ b/lib/flight_config/globber.rb
@@ -36,10 +36,10 @@ module FlightConfig
 
     module ClassMethods
       def glob_read(*a)
-        []
+        glob_regex = self.new(*a).path
+        Dir.glob(glob_regex)
       end
     end
   end
 end
-
 

--- a/lib/flight_config/globber.rb
+++ b/lib/flight_config/globber.rb
@@ -38,6 +38,7 @@ module FlightConfig
       def glob_read(*a)
         glob_regex = self.new(*a).path
         Dir.glob(glob_regex)
+           .map { |_path| new() }
       end
     end
   end

--- a/lib/flight_config/globber.rb
+++ b/lib/flight_config/globber.rb
@@ -26,48 +26,20 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-require 'flight_config/core'
-require 'ice_nine'
+require 'flight_config/reader'
 
 module FlightConfig
-  module Reader
-    include Core
-
+  module Globber
     def self.included(base)
       base.extend(ClassMethods)
     end
 
     module ClassMethods
-      def new!(*a)
-        new(*a).tap do |config|
-          yield config if block_given?
-          IceNine.deep_freeze(config.__data__)
-        end
+      def glob_read(*a)
+        []
       end
-
-      def allow_missing_read(fetch: false)
-        if fetch
-          @allow_missing_read ||= false
-        else
-          @allow_missing_read = true
-        end
-      end
-
-      def read(*a)
-        new!(*a) do |config|
-          if File.exists?(config.path)
-            Core.log(config, 'read')
-            Core.read(config)
-          elsif allow_missing_read(fetch: true)
-            Core.log(config, 'read (missing)')
-          else
-            raise MissingFile, "The file does not exist: #{config.path}"
-          end
-        end
-      end
-      alias_method :load, :read
     end
   end
-  Loader = Reader
 end
+
 

--- a/lib/flight_config/log.rb
+++ b/lib/flight_config/log.rb
@@ -32,8 +32,12 @@ module FlightConfig
   class << self
     attr_accessor :logger
 
+    def default_log_path
+      '/tmp/flight_config.log'
+    end
+
     def logger
-      @logger ||= Logger.new('/dev/null')
+      @logger ||= Logger.new(FlightConfig.default_log_path)
     end
   end
 

--- a/lib/flight_config/reader.rb
+++ b/lib/flight_config/reader.rb
@@ -66,6 +66,10 @@ module FlightConfig
         end
       end
       alias_method :load, :read
+
+      def glob_read(*a)
+        []
+      end
     end
   end
   Loader = Reader

--- a/spec/flight_config/globber_spec.rb
+++ b/spec/flight_config/globber_spec.rb
@@ -79,6 +79,10 @@ RSpec.describe FlightConfig::Globber do
         it 'returns objects of the correct type' do
           expect(subject.first.class).to eq(glob_class)
         end
+
+        it 'resolves the arguments correctly' do
+          expect(subject.first.args).to eq(name_args)
+        end
       end
     end
 

--- a/spec/flight_config/globber_spec.rb
+++ b/spec/flight_config/globber_spec.rb
@@ -47,34 +47,44 @@ RSpec.describe FlightConfig::Globber do
   describe '::glob_read' do
     include_fakefs
 
-    shared_examples 'with arity' do |num_inputs|
-      let(:input_args) { Array.new(num_inputs, nil) }
+    shared_examples 'with variable initializer' do
+      let(:input_args) { Array.new(num_inputs, '*') }
       subject { glob_class.glob_read(*input_args) }
 
-      context "when initialized with #{num_inputs} input(s)" do
-        context 'without any existing configs' do
-          it 'returns an empty array' do
-            expect(subject).to eq([])
-          end
+      context 'without any existing configs' do
+        it 'returns an empty array' do
+          expect(subject).to eq([])
+        end
+      end
+
+      context 'with a single existing configs' do
+        let(:name) { 'first-test-config' }
+        let(:name_args) do
+          args = Array.new(num_inputs) { |i| "arg#{i}" }
+          args[-1] = name
+          args
         end
 
-        context 'with a single existing configs' do
-          let(:name) { 'first-test-config' }
+        before do
+          path = glob_class.new(*name_args).path
+          FileUtils.mkdir_p(File.dirname(path))
+          FileUtils.touch(path)
+        end
 
-          before do
-            path = glob_class.new(name).path
-            FileUtils.mkdir_p(File.dirname(path))
-            FileUtils.touch(path)
-          end
-
-          xit 'finds a single config' do
-            expect(subject.length).to be(1)
-          end
+        it 'finds a single config' do
+          expect(subject.length).to be(1)
         end
       end
     end
 
-    include_examples 'with arity', 1
-    include_examples 'with arity', 3
+    context 'with a single input initializer' do
+      let(:num_inputs) { 1 }
+      include_examples 'with variable initializer'
+    end
+
+    context 'with a single input initializer' do
+      let(:num_inputs) { 3 }
+      include_examples 'with variable initializer'
+    end
   end
 end

--- a/spec/flight_config/globber_spec.rb
+++ b/spec/flight_config/globber_spec.rb
@@ -35,10 +35,11 @@ RSpec.describe FlightConfig::Globber do
       include FlightConfig::Reader
       include nodule
 
-      attr_reader :path
+      attr_reader :path, :args
 
-      def initialize(*a)
-        parts = a.map { |arg| "var/#{arg}" }
+      def initialize(*args)
+        @args = args
+        parts = args.map { |arg| "var/#{arg}" }
         @path = File.join('/tmp', *parts, 'etc/config.yaml')
       end
     end
@@ -73,6 +74,10 @@ RSpec.describe FlightConfig::Globber do
 
         it 'finds a single config' do
           expect(subject.length).to be(1)
+        end
+
+        it 'returns objects of the correct type' do
+          expect(subject.first.class).to eq(glob_class)
         end
       end
     end

--- a/spec/flight_config/reader_spec.rb
+++ b/spec/flight_config/reader_spec.rb
@@ -27,6 +27,7 @@
 #
 
 require 'flight_config/reader'
+require 'flight_config/globber_spec'
 
 RSpec.describe FlightConfig::Reader do
   describe '::read' do
@@ -71,52 +72,5 @@ RSpec.describe FlightConfig::Reader do
       end
     end
   end
-
-  describe '::glob_read' do
-    include_fakefs
-
-    shared_examples 'with arity' do |num_inputs|
-      let(:input_args) { Array.new(num_inputs, nil) }
-      subject { glob_class.glob_read(*input_args) }
-
-      context "when initialized with #{num_inputs} input(s)" do
-        context 'without any existing configs' do
-          it 'returns an empty array' do
-            expect(subject).to eq([])
-          end
-        end
-
-        context 'with a single existing configs' do
-          let(:name) { 'first-test-config' }
-
-          before do
-            path = glob_class.new(name).path
-            FileUtils.mkdir_p(File.dirname(path))
-            FileUtils.touch(path)
-          end
-
-          xit 'finds a single config' do
-            expect(subject.length).to be(1)
-          end
-        end
-      end
-    end
-
-    let(:glob_class) do
-      nodule = described_class
-      Class.new do
-        include nodule
-
-        attr_reader :path
-
-        def initialize(*a)
-          parts = a.map { |arg| "var/#{arg}" }
-          @path = File.join('/tmp', *parts, 'etc/config.yaml')
-        end
-      end
-    end
-
-    include_examples 'with arity', 1
-    include_examples 'with arity', 3
-  end
 end
+

--- a/spec/flight_config/reader_spec.rb
+++ b/spec/flight_config/reader_spec.rb
@@ -29,9 +29,9 @@
 require 'flight_config/reader'
 
 RSpec.describe FlightConfig::Reader do
-  include_context 'with config utils'
-
   describe '::read' do
+    include_context 'with config utils'
+
     def read_subject
       config_class.read(subject_path)
     end
@@ -70,5 +70,53 @@ RSpec.describe FlightConfig::Reader do
         end
       end
     end
+  end
+
+  describe '::glob_read' do
+    include_fakefs
+
+    shared_examples 'with arity' do |num_inputs|
+      let(:input_args) { Array.new(num_inputs, nil) }
+      subject { glob_class.glob_read(*input_args) }
+
+      context "when initialized with #{num_inputs} input(s)" do
+        context 'without any existing configs' do
+          it 'returns an empty array' do
+            expect(subject).to eq([])
+          end
+        end
+
+        context 'with a single existing configs' do
+          let(:name) { 'first-test-config' }
+
+          before do
+            path = glob_class.new(name).path
+            FileUtils.mkdir_p(File.dirname(path))
+            FileUtils.touch(path)
+          end
+
+          xit 'finds a single config' do
+            expect(subject.length).to be(1)
+          end
+        end
+      end
+    end
+
+    let(:glob_class) do
+      nodule = described_class
+      Class.new do
+        include nodule
+
+        attr_reader :path
+
+        def initialize(*a)
+          parts = a.map { |arg| "var/#{arg}" }
+          @path = File.join('/tmp', *parts, 'etc/config.yaml')
+        end
+      end
+    end
+
+    include_examples 'with arity', 1
+    include_examples 'with arity', 3
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -35,6 +35,15 @@ require 'pry-byebug'
 require 'config_utils'
 
 RSpec.configure do |config|
+  module FakeFSUtils
+    def include_fakefs
+      require 'fakefs/spec_helpers'
+      include FakeFS::SpecHelpers
+    end
+  end
+
+  config.extend FakeFSUtils
+
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = ".rspec_status"
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -39,6 +39,11 @@ RSpec.configure do |config|
     def include_fakefs
       require 'fakefs/spec_helpers'
       include FakeFS::SpecHelpers
+
+      before do
+        FakeFS::FileSystem.clone(FlightConfig.default_log_path)
+        allow_any_instance_of(FakeFS::File).to receive(:flock)
+      end
     end
   end
 


### PR DESCRIPTION
This is very common operation that will need to be preformed for different config types. It is assumed that any initialisation variables are encoded in the path. This makes it possible to infer the input args from the path and class type alone.