### PR TITLE
Stop flight_config from writing to a default logger

### DIFF
--- a/lib/flight_config/log.rb
+++ b/lib/flight_config/log.rb
@@ -29,10 +29,6 @@ require 'logger'
 module FlightConfig
   class << self
     attr_accessor :logger
-
-    def default_log_path
-      '/tmp/flight_config.log'
-    end
   end
 
   module Log

--- a/lib/flight_config/log.rb
+++ b/lib/flight_config/log.rb
@@ -33,10 +33,6 @@ module FlightConfig
     def default_log_path
       '/tmp/flight_config.log'
     end
-
-    def logger
-      @logger ||= Logger.new(FlightConfig.default_log_path)
-    end
   end
 
   module Log
@@ -44,6 +40,8 @@ module FlightConfig
       status = respond_to_missing?(s)
       if status == :log_method
         FlightConfig.logger.send(s, *a, &b)
+      elsif status == :nil_logger
+        # noop
       else
         super
       end
@@ -51,6 +49,7 @@ module FlightConfig
 
     def self.respond_to_missing?(s)
       return :log_method if FlightConfig.logger.respond_to?(s)
+      return :nil_logger if FlightConfig.logger.nil?
       super
     end
   end

--- a/lib/flight_config/version.rb
+++ b/lib/flight_config/version.rb
@@ -25,5 +25,5 @@
 # https://github.com/openflighthpc/flight_config
 #==============================================================================
 module FlightConfig
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end

--- a/spec/config_utils.rb
+++ b/spec/config_utils.rb
@@ -93,7 +93,7 @@ RSpec.shared_context 'with config utils' do |*additional_includes|
 
     it 'can set a default useing the TTY::Config initializer' do
       value = '__data__initializer-value'
-      config_class.define_method(:__data__initialize) do |config|
+      config_class.send(:define_method, :__data__initialize) do |config|
         config.set(:key, value: value)
       end
       expect(subject.__data__.fetch(:key)).to eq(value)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -39,7 +39,6 @@ RSpec.configure do |config|
       include FakeFS::SpecHelpers
 
       before do
-        FakeFS::FileSystem.clone(FlightConfig.default_log_path)
         allow_any_instance_of(FakeFS::File).to receive(:flock)
       end
     end


### PR DESCRIPTION
The default logger is within `/tmp` and therefore is not picked up by `logrotate`. This can cause issues if a config needs to be loaded through `FlightConfig` inorder to permanently set the log path. This first config load is going to `/tmp` and slowly growing in size.

From now on, there is no logging if the logger isn't setup.