### PR TITLE
Port the index code from FligthMetal to FlightConfig

### DIFF
--- a/lib/flight_config/exceptions.rb
+++ b/lib/flight_config/exceptions.rb
@@ -30,4 +30,5 @@ module FlightConfig
   class ResourceBusy < FlightConfigError; end
   class MissingFile < FlightConfigError; end
   class CreateError < FlightConfigError; end
+  class InvalidIndex < FlightConfigError; end
 end

--- a/lib/flight_config/has_indices.rb
+++ b/lib/flight_config/has_indices.rb
@@ -1,0 +1,53 @@
+#==============================================================================
+# Copyright (C) 2019-present Alces Flight Ltd.
+#
+# This file is part of FlightConfig.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# FlightConfig is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with FlightConfig. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on FlightConfig, please visit:
+# https://github.com/openflighthpc/flight_config
+#==============================================================================
+
+module FightConfig
+  module HasIndices
+    def included(base)
+      base.extend(ClassMethods)
+    end
+
+    module ClassMethods
+      def has_indices(klass, &b)
+        @indices ||= []
+        @indices << [klass, b]
+      end
+
+      def indices
+        @indices ||= []
+        base = (defined?(super) ? super : [])
+        [*base, *@indices]
+      end
+    end
+
+    def generate_indices
+      self.class.indices.each do |klass, block|
+        instance_exec(klass.method(:create_or_update), &block)
+      end
+    end
+  end
+end

--- a/lib/flight_config/indexable.rb
+++ b/lib/flight_config/indexable.rb
@@ -63,7 +63,7 @@ module FlightConfig
 
     def __data__
       @__data__ ||= begin
-        if !valid?
+        if __read_mode__ && !valid?
           FlightConfig::Core.log(self, 'Removing index')
           FileUtils.rm_f path
           raise InvalidIndex, 'Failed to load index as it is invalid'

--- a/lib/flight_config/indexable.rb
+++ b/lib/flight_config/indexable.rb
@@ -68,6 +68,7 @@ module FlightConfig
           FileUtils.rm_f path
           raise InvalidIndex, 'Failed to load index as it is invalid'
         end
+        {}
       end
     end
   end

--- a/lib/flight_config/indexable.rb
+++ b/lib/flight_config/indexable.rb
@@ -56,5 +56,9 @@ module FlightConfig
         end
       end
     end
+
+    def __data__
+      {}
+    end
   end
 end

--- a/lib/flight_config/indexable.rb
+++ b/lib/flight_config/indexable.rb
@@ -1,0 +1,60 @@
+#==============================================================================
+# Copyright (C) 2019-present Alces Flight Ltd.
+#
+# This file is part of FlightConfig.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# FlightConfig is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with FlightConfig. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on FlightConfig, please visit:
+# https://github.com/openflighthpc/flight_config
+#==============================================================================
+
+require 'flight_config/reader'
+require 'flight_config/globber'
+
+module FlightConfig
+  module Indexable
+    include FlightConfig::Reader
+    include FlightConfig::Globber
+
+    def self.included(base)
+      base.extend(ClassMethods)
+    end
+
+    module ClassMethods
+      include FlightConfig::Reader::ClassMethods
+
+      def glob_read(*a)
+        super.reject do |index|
+          next if index.valid?
+          FileUtils.rm_f path
+          true
+        end
+      end
+
+      def create_or_update(*a)
+        new!(*a, read_mode: true) do |index|
+          Core.log(index, "Generating index")
+          FileUtils.mkdir_p File.dirname(index.path)
+          FileUtils.touch index.path
+        end
+      end
+    end
+  end
+end

--- a/lib/flight_config/indexable.rb
+++ b/lib/flight_config/indexable.rb
@@ -57,8 +57,18 @@ module FlightConfig
       end
     end
 
+    def valid?
+      raise NotImplementedError
+    end
+
     def __data__
-      {}
+      @__data__ ||= begin
+        if !valid?
+          FlightConfig::Core.log(self, 'Removing index')
+          FileUtils.rm_f path
+          raise InvalidIndex, 'Failed to load index as it is invalid'
+        end
+      end
     end
   end
 end

--- a/lib/flight_config/updater.rb
+++ b/lib/flight_config/updater.rb
@@ -74,7 +74,7 @@ module FlightConfig
         mode = File.exists?(_path(*a))
         new!(*a, read_mode: mode) do |config|
           Updater.create_or_update(config, action: 'create_or_update', &b)
-        end
+        end.tap { |c| c.generate_indices if c.respond_to?(:generate_indices) }
       end
 
       def create(*a, &b)

--- a/lib/flight_config/version.rb
+++ b/lib/flight_config/version.rb
@@ -25,5 +25,5 @@
 # https://github.com/openflighthpc/flight_config
 #==============================================================================
 module FlightConfig
-  VERSION = "0.2.0"
+  VERSION = "0.3.0"
 end

--- a/spec/config_utils.rb
+++ b/spec/config_utils.rb
@@ -57,7 +57,6 @@ RSpec.shared_context 'with config utils' do |*additional_includes|
 
   def self.it_loads_empty_subject_config
     it 'loads an empty hash equivalent TTY::Config object' do
-      expect(subject.__data__).to be_a(TTY::Config)
       expect(subject.__data__.to_h).to be_empty
     end
   end

--- a/spec/flight_config/indexable_spec.rb
+++ b/spec/flight_config/indexable_spec.rb
@@ -55,7 +55,17 @@ RSpec.describe FlightConfig::Indexable do
     context 'with an existing config' do
       with_existing_subject_file
 
-      include_examples 'creates the index'
+      context 'without any initial data' do
+        include_examples 'creates the index'
+      end
+
+      context 'with initial data' do
+        before do
+          File.write(subject_path, YAML.dump(key: 'I should not be loaded'))
+        end
+
+        include_examples 'creates the index'
+      end
     end
   end
 end

--- a/spec/flight_config/indexable_spec.rb
+++ b/spec/flight_config/indexable_spec.rb
@@ -1,0 +1,61 @@
+#==============================================================================
+# Copyright (C) 2019-present Alces Flight Ltd.
+#
+# This file is part of FlightConfig.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# FlightConfig is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with FlightConfig. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on FlightConfig, please visit:
+# https://github.com/openflighthpc/flight_config
+#==============================================================================
+
+require 'flight_config/indexable'
+
+RSpec.describe FlightConfig::Indexable do
+  describe '::create_or_update' do
+    include_context 'with config utils'
+
+    def create_or_update_index
+      config_class.create_or_update(subject_path)
+    end
+
+    subject { create_or_update_index }
+
+    shared_examples 'creates the index' do
+      it_loads_empty_subject_config
+
+      it 'ensures the file exists' do
+        expect(File).to exist(subject.path)
+      end
+    end
+
+
+    context 'without an existing config' do
+      with_missing_subject_file
+
+      include_examples 'creates the index'
+    end
+
+    context 'with an existing config' do
+      with_existing_subject_file
+
+      include_examples 'creates the index'
+    end
+  end
+end


### PR DESCRIPTION
This PR is broadly based on what has been implemented within `FlightMetal`. An "Index" is a special type of `Config` that has been designed to reference other models. It has validation built into it that removes stale indices on the fly.

It is used in metal to link nodes to their groups.